### PR TITLE
pass down a ref callback to custom component instead of relying on the r…

### DIFF
--- a/src/components/ReactComponent.jsx
+++ b/src/components/ReactComponent.jsx
@@ -10,6 +10,7 @@ export default class ReactComponent extends Field {
    */
   constructor(component, options, data) {
     super(component, options, data);
+    this.reactInstance = null;
   }
 
   /**
@@ -41,6 +42,15 @@ export default class ReactComponent extends Field {
   }
 
   /**
+   * Callback ref to store a reference to the node.
+   *
+   * @param element - the node
+   */
+  setReactInstance(element) {
+    this.reactInstance = element;
+  }
+
+  /**
    * The third phase of component building where the component has been attached to the DOM as 'element' and is ready
    * to have its javascript events attached.
    *
@@ -57,7 +67,7 @@ export default class ReactComponent extends Field {
     });
 
     if (this.refs[`react-${this.id}`]) {
-      this.reactInstance = this.attachReact(this.refs[`react-${this.id}`]);
+      this.attachReact(this.refs[`react-${this.id}`], this.setReactInstance.bind(this));
       if (this.shouldSetValue) {
         this.setValue(this.dataForSetting);
         this.updateValue(this.dataForSetting);
@@ -81,8 +91,9 @@ export default class ReactComponent extends Field {
    * Override this function to insert your custom component.
    *
    * @param element
+   * @param ref - callback ref
    */
-  attachReact(element) {
+  attachReact(element, ref) {
     return;
   }
 


### PR DESCRIPTION
…eturn value of ReactDOM.render

As per what React says:

> ReactDOM.render() currently returns a reference to the root ReactComponent instance. However, using this return value is legacy and should be avoided because future versions of React may render components asynchronously in some cases. If you need a reference to the root ReactComponent instance, the preferred solution is to attach a callback ref to the root element.

In some situations, ReactDOM.render returns null even if we use a class component. As specified by React, one preferred way to solve this is to rely on a callback ref.

