### PR TITLE
feat: Typescript typings 

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,9 +6,10 @@
   "scripts": {
     "test": "karma start --single-run",
     "build": "babel ./src --ignore=*.spec.js --out-dir ./lib --presets es2015,react,stage-2",
+    "build-types": "npx tsc",
     "lint": "eslint src",
     "watch": "babel ./src --watch --ignore=*.spec.js --out-dir ./lib --presets es2015,react,stage-2",
-    "prepublish": "npm run lint && npm run build"
+    "prepublish": "npm run lint && npm run build && npm run build-types"
   },
   "repository": {
     "type": "git",
@@ -70,6 +71,7 @@
     "react-test-renderer": "^17.0.2",
     "react-transform-catch-errors": "^1.0.0",
     "sinon": "^12.0.1",
+    "typescript": "^4.5.2",
     "webpack": "^5.65.0"
   },
   "files": [

--- a/src/components/Errors.jsx
+++ b/src/components/Errors.jsx
@@ -10,6 +10,10 @@ const Errors = (props) => {
     return !!error;
   };
 
+  /**
+   * @param {string|any[]} error
+   * @returns {string|unknown[]|*}
+   */
   const formatError = (error) => {
     if (typeof error === 'string') {
       return error;

--- a/src/components/Form.jsx
+++ b/src/components/Form.jsx
@@ -5,6 +5,10 @@ import _isEqual from 'lodash/isEqual';
 import {Formio} from 'formiojs';
 const FormioForm = Formio.Form;
 
+/**
+ * @param {FormProps} props
+ * @returns {JSX.Element}
+ */
  const Form = (props) => {
   let instance;
   let createPromise;
@@ -93,6 +97,41 @@ const FormioForm = Formio.Form;
   return <div ref={el => element = el} />;
 };
 
+/**
+ * @typedef {object} Options
+ * @property {boolean} [readOnly]
+ * @property {boolean} [noAlerts]
+ * @property {object} [i18n]
+ * @property {string} [template]
+ * @property {boolean} [saveDraft]
+ */
+
+/**
+ * @typedef {object} FormProps
+ * @property {string} [src]
+ * @property {string} [url]
+ * @property {object} [form]
+ * @property {object} [submission]
+ * @property {Options} [options]
+ * @property {function} [onPrevPage]
+ * @property {function} [onNextPage]
+ * @property {function} [onCancel]
+ * @property {function} [onChange]
+ * @property {function} [onCustomEvent]
+ * @property {function} [onComponentChange]
+ * @property {function} [onSubmit]
+ * @property {function} [onSubmitDone]
+ * @property {function} [onFormLoad]
+ * @property {function} [onError]
+ * @property {function} [onRender]
+ * @property {function} [onAttach]
+ * @property {function} [onBuild]
+ * @property {function} [onFocus]
+ * @property {function} [onBlur]
+ * @property {function} [onInitialized]
+ * @property {function} [formReady]
+ * @property {any} [formioform]
+ */
 Form.propTypes = {
   src: PropTypes.string,
   url: PropTypes.string,

--- a/src/components/FormBuilder.jsx
+++ b/src/components/FormBuilder.jsx
@@ -1,4 +1,4 @@
-import React, {useEffect, useRef, useState, useCallback, useLayoutEffect} from 'react';
+import React, {useEffect, useRef, useCallback, useLayoutEffect} from 'react';
 import PropTypes from 'prop-types';
 import {FormBuilder as FormioFormBuilder} from 'formiojs';
 
@@ -50,7 +50,7 @@ const FormBuilder = (props) => {
 
   useEffect(() => {
     initializeBuilder(props);
-    return () => (builderRef.current ? builderRef.current.instance.destroy(true) : null)
+    return () => (builderRef.current ? builderRef.current.instance.destroy(true) : null);
   }, [builderRef]);
 
   const elementDidMount = useCallback((el) => element = el);

--- a/src/types.js
+++ b/src/types.js
@@ -2,6 +2,20 @@ import PropTypes from 'prop-types';
 
 export const AllItemsPerPage = 'all';
 
+/**
+ * @typedef Column
+ * @type {object}
+ * @property {string} key
+ * @property {(boolean|string|Function)} sort
+ * @property {string} title
+ * @property {Function} value
+ * @property {number} width
+ */
+
+/**
+ * @constant
+ * @type {Column}
+ */
 export const Column = PropTypes.shape({
   key: PropTypes.string.isRequired,
   sort: PropTypes.oneOfType([
@@ -14,8 +28,26 @@ export const Column = PropTypes.shape({
   width: PropTypes.number,
 });
 
+/**
+ * @constant
+ * @type {Column[]}
+ */
 export const Columns = PropTypes.arrayOf(Column);
 
+/**
+ * @typedef Operation
+ * @type {object}
+ * @property {string} [action]
+ * @property {string} [buttonType]
+ * @property {string} [icon]
+ * @property {Function} [permissionsResolver]
+ * @property {string} [title]
+ */
+
+/**
+ * @constant
+ * @type {Operation}
+ */
 export const Operation = PropTypes.shape({
   action: PropTypes.string.isRequired,
   buttonType: PropTypes.string,
@@ -24,8 +56,23 @@ export const Operation = PropTypes.shape({
   title: PropTypes.string,
 });
 
+/**
+ * @constant
+ * @type {Operation[]}
+ */
 export const Operations = PropTypes.arrayOf(Operation);
 
+/**
+ * @typedef LabelValue
+ * @type {object}
+ * @property {string} label
+ * @property {number} value
+ */
+
+/**
+ * @constant
+ * @type {(number|LabelValue)}
+ */
 export const PageSize = PropTypes.oneOfType([
   PropTypes.number,
   PropTypes.shape({
@@ -35,4 +82,8 @@ export const PageSize = PropTypes.oneOfType([
   PropTypes.oneOf([AllItemsPerPage]),
 ]);
 
+/**
+ * @constant
+ * @type {PageSize[]}
+ */
 export const PageSizes = PropTypes.arrayOf(PageSize);

--- a/src/utils.js
+++ b/src/utils.js
@@ -25,6 +25,9 @@ export const getComponentDefaultColumn = (component) => ({
   },
 });
 
+/**
+ * @param {import('./types').Column[]} columns
+ */
 export function setColumnsWidth(columns) {
   if (columns.length > 6) {
     columns.forEach((column) => {
@@ -43,6 +46,10 @@ export function setColumnsWidth(columns) {
   }
 }
 
+/**
+ * @param {Function} fn
+ * @returns {(function(*): void)|*}
+ */
 export const stopPropagationWrapper = (fn) => (event) => {
   event.stopPropagation();
   fn();

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,23 @@
+{
+  // Change this to match your project
+  "include": ["src/**/*"],
+  "compilerOptions": {
+    // Tells TypeScript to read JS files, as
+    // normally they are ignored as source files
+    "allowJs": true,
+    "jsx": "react",
+    // Generate d.ts files
+    "declaration": true,
+    // This compiler run should
+    // only output d.ts files
+    "emitDeclarationOnly": true,
+    // Types should go into this directory.
+    // Removing this would place the .d.ts files
+    // next to the .js files
+    "outDir": "lib",
+    // go to js file when using IDE functions like
+    // "Go to Definition" in VSCode
+    "declarationMap": true,
+    "noEmit": false
+  }
+}


### PR DESCRIPTION
Add Typescript typings to build, and push to the lib folder for inclusion in the published package.

- Add "build-types" script to packages.json , and run as part of the prepublish script.
- Add Jsdoc types to Form.jsx to provide stronger typedef.

Relates to #184 