### PR TITLE
use ref instead of state to store previous form json

### DIFF
--- a/src/components/Form.jsx
+++ b/src/components/Form.jsx
@@ -14,7 +14,7 @@ const FormioForm = Formio.Form;
   let createPromise;
   let element;
   const [formio, setFormio] = useState(undefined);
-  const [jsonForm, setJsonForm] = useState(undefined);
+  jsonForm = useRef();
 
   useEffect(() => () => formio ? formio.destroy(true) : null, [formio]);
 
@@ -67,8 +67,8 @@ const FormioForm = Formio.Form;
 
   useEffect(() => {
     const {form, url} = props;
-    if (form && !_isEqual(form, jsonForm)) {
-      setJsonForm(form);
+    if (form && !_isEqual(form, jsonForm.current)) {
+      jsonForm.current = form;
       createWebformInstance(form).then(() => {
       if (formio) {
         formio.form = form;
@@ -80,7 +80,7 @@ const FormioForm = Formio.Form;
       });
       initializeFormio();
     }
-  }, [props.form, jsonForm]);
+  }, [props.form]);
 
   useEffect(() => {
     const {options = {}} = props;

--- a/src/components/Form.jsx
+++ b/src/components/Form.jsx
@@ -14,7 +14,7 @@ const FormioForm = Formio.Form;
   let createPromise;
   let element;
   const [formio, setFormio] = useState(undefined);
-  jsonForm = useRef();
+  const jsonForm = useRef();
 
   useEffect(() => () => formio ? formio.destroy(true) : null, [formio]);
 


### PR DESCRIPTION
this fix creating multiple formio instances in react 18 strict mode

related to https://github.com/formio/react/issues/135