### PR TITLE
add methode before on submit so it can be generated in typing

### DIFF
--- a/src/components/ReactComponent.jsx
+++ b/src/components/ReactComponent.jsx
@@ -30,6 +30,15 @@ export default class ReactComponent extends Field {
   destroy() {
     return super.destroy();
   }
+  /**
+   * This method is called before a form is submitted.
+   * It is used to perform any necessary actions or checks before the form data is sent.
+   * 
+   */
+
+  beforeSubmit(){
+    return super.beforeSubmit()
+  }
 
   /**
    * The second phase of component building where the component is rendered as an HTML string.


### PR DESCRIPTION
"There is a method called [beforeSubmit] in Formio that is used before a form is submitted. It is useful for performing any necessary actions or checks on the form data before it is sent to the server. However, in the latest update, it seems that there is an error indicating that the method does not exist because of the ts typing 