### PR TITLE
fix: README typo in examples 

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ Without Components:
 With Components:
 
 ```javascript
-<FormBuilder form={
+<FormBuilder form={{
  display: 'form',
  components: [
  {


### PR DESCRIPTION
Fixing typo in `<FormBuilder />` example