### PR TITLE
Added missing proptype (saveText, saveForm) for FormEdit

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -4,7 +4,11 @@ All notable changes to this project will be documented in this file
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
-## [Unreleased: 5.2.4-rc.3]
+## [Unreleased: 5.2.4-rc.4]
+### Fixed
+ - Updated `FormEdit` proptypes to match the props used within the component. Adds `saveForm` function and `saveText` string
+
+## 5.2.4-rc.3
 ### Fixed
  - FIO-6440: Upgrades dependencies and fixes warnings
 

--- a/src/components/FormEdit.jsx
+++ b/src/components/FormEdit.jsx
@@ -157,7 +157,8 @@ FormEdit.propTypes = {
   form: PropTypes.object.isRequired,
   options: PropTypes.object,
   builder: PropTypes.any,
-  onSave: PropTypes.func
+  onSave: PropTypes.func,
+  saveText: PropTypes.string
 };
 
 FormEdit.defaultProps = {

--- a/src/components/FormEdit.jsx
+++ b/src/components/FormEdit.jsx
@@ -157,7 +157,7 @@ FormEdit.propTypes = {
   form: PropTypes.object.isRequired,
   options: PropTypes.object,
   builder: PropTypes.any,
-  onSave: PropTypes.func,
+  saveForm: PropTypes.func,
   saveText: PropTypes.string
 };
 


### PR DESCRIPTION
Pretty basic update, but currently the saveText prop defaults to '' and is not a valid prop in typescript.  This causes typescript to complain.
```
Property 'saveText' does not exist on type 'IntrinsicAttributes & Pick<InferProps<typeof propTypes>, "options" | "builder" | "onSave"> & InexactPartial<Pick<InferProps<typeof propTypes>, "form">> & InexactPartial<...>'
```
This adds the prop `saveText` to the proptypes object for the FormEdit component.

I would argue that this prop should be required since the default value is an empty string but that is something that could be discussed as a follow on to this PR.


This also replaces the `onSave` proptype with `saveForm`, since `onSave` is not found anywhere in the code for that component whereas `saveForm` is used but isn't defined in the proptypes