### PR TITLE
remove babel-polyfill package

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,6 @@
   },
   "homepage": "https://github.com/formio/react-formio#readme",
   "dependencies": {
-    "babel-polyfill": "^6.26.0",
     "core-js": "^3.32.0",
     "eventemitter2": "^6.4.5",
     "lodash": "^4.17.21",


### PR DESCRIPTION
we want to remove the babel-polyfill package from the dependencies because it is installing a version of core-js that contains vulnerabilities.

<img width="574" alt="image" src="https://github.com/formio/react/assets/13240476/e1293fab-cfd1-4ef0-997d-6fa00d3ddd1d">
