### PR TITLE
FIO-9587: add interface to FormioProvider to allow for extending Formio object

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -24,7 +24,7 @@ A clear and concise description of what you expected to happen.
 If applicable, add screenshots to help explain your problem.
 
 **Sandbox Example**
-A reproducible example from an online editor such as CodeSandbox or StackBlitz 
+A reproducible example from an online editor such as CodeSandbox or StackBlitz
 
 **Desktop (please complete the following information):**
 
@@ -41,6 +41,3 @@ A reproducible example from an online editor such as CodeSandbox or StackBlitz
 
 **Additional context**
 Add any other context about the problem here.
-
-
-

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,10 +2,10 @@
 
 Thank you for helping this project become a better library :)
 
-- [Triage](#triage)
-- [Reporting Bugs](#reporting-bugs)
-- [Providing a feature request](#providing-a-feature-request)
-- [Pull requests](#pull-requests)
+-   [Triage](#triage)
+-   [Reporting Bugs](#reporting-bugs)
+-   [Providing a feature request](#providing-a-feature-request)
+-   [Pull requests](#pull-requests)
 
 ## Triage
 
@@ -23,21 +23,21 @@ Open an issue, making sure to follow the Feature request template.
 
 ### Getting started
 
-- If there isn't one already, open an issue describing the bug or feature request that you are going to solve in your pull request.
-- Create a fork of react-native-maps
-  - If you already have a fork, make sure it is up to date
-- Git clone your fork and run `yarn` in the base of the cloned repo to setup your local development environment.
-- Create a branch from the master branch to start working on your changes.
+-   If there isn't one already, open an issue describing the bug or feature request that you are going to solve in your pull request.
+-   Create a fork of react-native-maps
+    -   If you already have a fork, make sure it is up to date
+-   Git clone your fork and run `yarn` in the base of the cloned repo to setup your local development environment.
+-   Create a branch from the master branch to start working on your changes.
 
 ### Committing
 
-- When you made your changes, run `yarn lint` & `yarn test` to make sure the code you introduced doesn't cause any obvious issues.
-- When you are ready to commit your changes, use the [Github conventional commits](https://gist.github.com/qoomon/5dfcdf8eec66a051ecd85625518cfd13) convention for you commit messages, as we use your commits when releasing new versions.
-- Use present tense: "add awesome component" not "added awesome component"
-- Limit the first line of the commit message to 100 characters
-- Reference issues and pull requests before committing
+-   When you made your changes, run `yarn lint` & `yarn test` to make sure the code you introduced doesn't cause any obvious issues.
+-   When you are ready to commit your changes, use the [Github conventional commits](https://gist.github.com/qoomon/5dfcdf8eec66a051ecd85625518cfd13) convention for you commit messages, as we use your commits when releasing new versions.
+-   Use present tense: "add awesome component" not "added awesome component"
+-   Limit the first line of the commit message to 100 characters
+-   Reference issues and pull requests before committing
 
 ### Creating the pull request
 
-- The title of the PR needs to follow the same conventions as your commit messages, as it might be used in case of a squash merge.
-- Create the pull request against the beta branch.
+-   The title of the PR needs to follow the same conventions as your commit messages, as it might be used in case of a squash merge.
+-   Create the pull request against the beta branch.

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 A [React](http://facebook.github.io/react/) library for rendering out forms based on the [Form.io](https://www.form.io) platform.
 
-> **_NOTE:_**  The following documentation corresponds to version 6.x of @formio/react, which has not been released yet. For version-specific documentation, please see the relevant tag.
+> **_NOTE:_** The following documentation corresponds to version 6.x of @formio/react, which has not been released yet. For version-specific documentation, please see the relevant tag.
 
 ## Example Application
 
@@ -239,8 +239,45 @@ A React context provider component that is required when using some hooks and co
 
 | Name       | Type   | Description                              |
 | ---------- | ------ | ---------------------------------------- |
+| Formio     | object | The Formio object to be used.
 | baseUrl    | string | The base url of a Form.io server.        |
 | projectUrl | string | The url of a Form.io enterprise project. |
+
+#### Examples
+
+Render a simple form from your self hosted Form.io deployment:
+
+```JSX
+import { createRoot } from 'react-dom/client';
+import { Form, FormioProvider } from '@formio/react';
+
+const domNode = document.getElementById('root');
+const root = createRoot(domNode);
+
+root.render(
+  <FormioProvider baseUrl="https://myformiodeployment.example.com/" projectUrl="https://myformiodeployment.example.com/myproject">
+    <Form src="https://myformiodeployment.example.com/myproject/myexampleform" />
+  </FormioProvider>
+);
+```
+
+Extend the Formio object to use external modules:
+
+```JSX
+import { createRoot } from 'react-dom/client';
+import { Form, FormioProvider } from '@formio/react';
+import { Formio } from '@formio/js';
+import premium from '@formio/premium';
+
+const domNode = document.getElementById('root');
+const root = createRoot(domNode);
+
+Formio.use(premium);
+root.render(
+  <FormioProvider Formio={Formio}>
+    <Form src="https://myproject.form.io/myformwithpremiumcomponents" />
+  </FormioProvider>
+);
 
 ### Form
 


### PR DESCRIPTION
## Link to Jira Ticket

https://formio.atlassian.net/browse/FIO-9587

## Description

This PR adds an interface with which you can extend the Formio object that you pass into the FormioProvider

## Breaking Changes / Backwards Compatibility

n/a

## Dependencies

n/a

## How has this PR been tested?

n/a

## Checklist:

-   [x] I have completed the above PR template
-   [ ] I have commented my code, particularly in hard-to-understand areas
-   [ ] I have made corresponding changes to the documentation (if applicable)
-   [ ] My changes generate no new warnings
-   [ ] My changes include tests that prove my fix is effective (or that my feature works as intended)
-   [ ] New and existing unit/integration tests pass locally with my changes
-   [ ] Any dependent changes have corresponding PRs that are listed above
