### PR TITLE
FIO-9944: Fixes an issue where some form instances will not be destroyed

### DIFF
--- a/src/components/Form.tsx
+++ b/src/components/Form.tsx
@@ -252,7 +252,8 @@ const getEffectiveProps = (props: FormProps) => {
 export const Form = (props: FormProps) => {
 	const renderElement = useRef<HTMLDivElement | null>(null);
 	const currentFormJson = useRef<FormType | null>(null);
-	const { formConstructor, formSource, formReadyCallback } = getEffectiveProps(props);
+	const { formConstructor, formSource, formReadyCallback } =
+		getEffectiveProps(props);
 	const {
 		src,
 		form,
@@ -295,9 +296,10 @@ export const Form = (props: FormProps) => {
 				console.warn('Form source not found');
 				return;
 			}
-			currentFormJson.current = formSource && typeof formSource !== 'string'
-				? structuredClone(formSource)
-				: null;
+			currentFormJson.current =
+				formSource && typeof formSource !== 'string'
+					? structuredClone(formSource)
+					: null;
 			const instance = await createWebformInstance(
 				formConstructor,
 				currentFormJson.current || formSource,
@@ -319,7 +321,12 @@ export const Form = (props: FormProps) => {
 				if (formReadyCallback) {
 					formReadyCallback(instance);
 				}
-				setFormInstance(instance);
+				setFormInstance((prevInstance: any) => {
+					if (prevInstance) {
+						prevInstance.destroy(true);
+					}
+					return instance;
+				});
 			} else {
 				console.warn('Failed to create form instance');
 			}
@@ -338,7 +345,8 @@ export const Form = (props: FormProps) => {
 	useEffect(() => {
 		let onAnyHandler = null;
 		if (formInstance && Object.keys(handlers).length > 0) {
-			onAnyHandler = (...args: [string, ...any[]]) => onAnyEvent(handlers, ...args);
+			onAnyHandler = (...args: [string, ...any[]]) =>
+				onAnyEvent(handlers, ...args);
 			formInstance.onAny(onAnyHandler);
 		}
 


### PR DESCRIPTION
## Link to Jira Ticket

https://formio.atlassian.net/browse/FIO-9944

## Description

We need to destroy existing form instance each time we set it or there will be some cases when the new form instance is set before the previouse one got destroyed to prevent the memory leak.

**Why have you chosen this solution?**

_Use this section to justify your choices_

## Breaking Changes / Backwards Compatibility

_Use this section to describe any potentially breaking changes this PR introduces or any effects this PR might have on backwards compatibility_

## Dependencies

_Use this section to list any dependent changes/PRs in other Form.io modules_

## How has this PR been tested?

_Use this section to describe how you tested your changes; if you haven't included automated tests, justify your reasoning_

## Checklist:

-   [ ] I have completed the above PR template
-   [ ] I have commented my code, particularly in hard-to-understand areas
-   [ ] I have made corresponding changes to the documentation (if applicable)
-   [ ] My changes generate no new warnings
-   [ ] My changes include tests that prove my fix is effective (or that my feature works as intended)
-   [ ] New and existing unit/integration tests pass locally with my changes
-   [ ] Any dependent changes have corresponding PRs that are listed above
