### PR TITLE
fix: prevent double loading spinners

### DIFF
--- a/src/templates.ts
+++ b/src/templates.ts
@@ -1,0 +1,12 @@
+import { Formio } from '@formio/js';
+
+const defaultTemplate = {
+  spinner: 'Loading...',
+  type: 'bootstrap3',
+  framework: 'bootstrap3'
+};
+
+// Initialize template on import to ensure it's set before any Form components are rendered
+Formio.setTemplate(defaultTemplate);
+
+export { defaultTemplate };


### PR DESCRIPTION
When using a recent version of this library and @formio/js, two loading spinners were displayed for a single form. This was caused by both libraries showing their loading indicators simultaneously.

This PR fixes the issue by:
1. Adding a default template configuration that sets a single loading indicator
2. Initializing the template on library import to ensure it's set before Form components render

The solution:
- Created a new `templates.ts` file that sets up the default template configuration
- The template is initialized when the library is imported, ensuring consistent loading indicator behavior
- Uses bootstrap3 framework for compatibility

To test:
1. Import the Form component from @formio/react
2. Create a form with a remote source like: `<Form src="https://examples.form.io/example" />`
3. Observe that only one loading spinner appears while the form loads

Fixes #590