### PR TITLE
feat: add support for custom fetch overrides via FormioProvider and F…

### DIFF
--- a/README.md
+++ b/README.md
@@ -259,11 +259,12 @@ A React context provider component that is required when using some hooks and co
 
 #### Props
 
-| Name       | Type   | Description                              |
-| ---------- | ------ | ---------------------------------------- |
-| Formio     | object | The Formio object to be used.            |
-| baseUrl    | string | The base url of a Form.io server.        |
-| projectUrl | string | The url of a Form.io enterprise project. |
+| Name        | Type               | Description                                                                                                                                                                                                                              |
+| ----------- | ------------------ | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Formio      | object             | The Formio object to be used.                                                                                                                                                                                                            |
+| baseUrl     | string             | The base url of a Form.io server.                                                                                                                                                                                                        |
+| projectUrl  | string             | The url of a Form.io enterprise project.                                                                                                                                                                                                 |
+| customFetch | FormioCustomFetch  | A custom fetch function to override the default fetch used by Form.io for all HTTP requests. Applied to all child `<Form>` components. Individual `<Form>` components can override this with their own `customFetch` prop. See below.    |
 
 #### Examples
 
@@ -302,6 +303,36 @@ root.render(
 );
 ```
 
+Apply a custom fetch function to all child forms:
+
+```tsx
+import { createRoot } from 'react-dom/client';
+import { Form, FormioProvider } from '@formio/react';
+import type { FormioCustomFetch } from '@formio/react';
+
+const myCustomFetch: FormioCustomFetch = async (url, init) => {
+	console.log('Custom fetch intercepted:', url);
+	return fetch(url, {
+		...init,
+		headers: { ...init?.headers, 'X-Custom-Header': 'my-value' },
+	});
+};
+
+const domNode = document.getElementById('root');
+const root = createRoot(domNode);
+
+root.render(
+	<FormioProvider
+		projectUrl="https://examples.form.io"
+		customFetch={myCustomFetch}
+	>
+		{/* Both forms use myCustomFetch */}
+		<Form src="https://examples.form.io/example" />
+		<Form src="https://examples.form.io/other" />
+	</FormioProvider>,
+);
+```
+
 ### Form
 
 A React component wrapper around [a Form.io form](https://help.form.io/developers/form-development/form-renderer#introduction). Able to take a JSON form definition or a Form.io form URL and render the form in your React application.
@@ -314,6 +345,7 @@ A React component wrapper around [a Form.io form](https://help.form.io/developer
 | `url`               | `string`                                                                                |         | The url of the form definition. Used in conjunction with a JSON form definition passed to `src`, this is used for file upload, OAuth, and other components or actions that need to know the URL of the Form.io form for further processing. The form will not be loaded from this url and the submission will not be saved here either. |
 | `submission`        | `JSON`                                                                                  |         | Submission data to fill the form. You can either load a previous submission or create a submission with some pre-filled data. If you do not provide a submissions the form will initialize an empty submission using default values from the form.                                                                                      |
 | `options`           | `FormOptions`                                                                           |         | The form options. See [here](https://help.form.io/developers/form-development/form-renderer#form-renderer-options) for more details.                                                                                                                                                                                                    |
+| `customFetch`       | `FormioCustomFetch`                                                                     |         | A custom fetch function to override the default fetch behavior used by Form.io for all HTTP requests. Overrides `customFetch` from `<FormioProvider>` if both are provided. Restored to the original on unmount.                                                                                                                        |
 | `onFormReady`       | `(instance: Webform) => void`                                                           |         | A callback function that gets called when the form has rendered. It is useful for accessing the underlying @formio/js Webform instance.                                                                                                                                                                                                 |
 | `onSubmit`          | `(submission: JSON, saved?: boolean) => void`                                           |         | A callback function that gets called when the submission has started. If `src` is not a Form.io server URL, this will be the final submit event.                                                                                                                                                                                        |
 | `onCancelSubmit`    | `() => void`                                                                            |         | A callback function that gets called when the submission has been canceled.                                                                                                                                                                                                                                                             |
@@ -440,6 +472,60 @@ const App = () => {
 }
 
 root.render(<App />);
+```
+
+#### Using `customFetch`
+
+Pass a custom fetch function to a single form instance. This is useful for adding custom headers, caching, error handling, or integrating with libraries like React Query:
+
+```tsx
+import { Form } from '@formio/react';
+import type { FormioCustomFetch } from '@formio/react';
+
+const myCustomFetch: FormioCustomFetch = async (url, init) => {
+	const response = await fetch(url, {
+		...init,
+		headers: {
+			...init?.headers,
+			Authorization: `Bearer ${getToken()}`,
+		},
+	});
+	if (!response.ok) {
+		showErrorToast(response.statusText);
+	}
+	return response;
+};
+
+const MyFormComponent = ({ formDefinition, submission }) => (
+	<Form
+		form={formDefinition}
+		submission={submission}
+		customFetch={myCustomFetch}
+	/>
+);
+```
+
+Override a provider-level `customFetch` for a specific form:
+
+```tsx
+import { Form, FormioProvider } from '@formio/react';
+
+const defaultFetch = async (url, init) => {
+	// Default custom fetch for all forms
+	return fetch(url, { ...init, credentials: 'include' });
+};
+
+const specialFetch = async (url, init) => {
+	// Special fetch for one specific form
+	return fetch(url, { ...init, cache: 'no-store' });
+};
+
+const App = () => (
+	<FormioProvider projectUrl="https://examples.form.io" customFetch={defaultFetch}>
+		<Form src="https://examples.form.io/form1" />  {/* uses defaultFetch */}
+		<Form src="https://examples.form.io/form2" customFetch={specialFetch} />  {/* uses specialFetch */}
+	</FormioProvider>
+);
 ```
 
 #### Usage in Next.js

--- a/src/components/Form.tsx
+++ b/src/components/Form.tsx
@@ -1,7 +1,8 @@
-import { CSSProperties, useEffect, useRef, useState } from 'react';
-import { EventEmitter, Form as FormClass, Webform, Utils } from '@formio/js';
+import { CSSProperties, useContext, useEffect, useRef, useState } from 'react';
+import { EventEmitter, Form as FormClass, Formio, Webform, Utils } from '@formio/js';
 import { Component, Form as CoreFormType } from '@formio/core';
 import structuredClone from '@ungap/structured-clone';
+import { FormioContext, FormioCustomFetch } from '../contexts/FormioContext';
 
 export type PartialExcept<T, K extends keyof T> = Partial<Omit<T, K>> &
 	Required<Pick<T, K>>;
@@ -53,6 +54,33 @@ export type FormProps = {
 	options?: FormOptions;
 	formioform?: FormConstructor;
 	FormClass?: FormConstructor;
+	/**
+	 * A custom fetch function to override the default fetch behavior
+	 * used by Form.io for all HTTP requests (loading form definitions,
+	 * submitting data, fetching resources, etc.).
+	 *
+	 * When provided, this function is set on the Formio class's static
+	 * `fetch` property for this form's lifecycle. When the component
+	 * unmounts, the original fetch is restored.
+	 *
+	 * This prop takes precedence over `customFetch` provided via
+	 * `<FormioProvider>`.
+	 *
+	 * @example
+	 * ```tsx
+	 * <Form
+	 *   form={formDefinition}
+	 *   customFetch={async (url, init) => {
+	 *     const response = await fetch(url, {
+	 *       ...init,
+	 *       headers: { ...init?.headers, 'X-Custom-Header': 'value' },
+	 *     });
+	 *     return response;
+	 *   }}
+	 * />
+	 * ```
+	 */
+	customFetch?: FormioCustomFetch;
 	formReady?: (instance: Webform) => void;
 	onFormReady?: (instance: Webform) => void;
 	onPrevPage?: (page: number, submission: Submission) => void;
@@ -113,6 +141,7 @@ const onAnyEvent = (
 		| 'formReady'
 		| 'formioform'
 		| 'Formio'
+		| 'customFetch'
 	>,
 	...args: [string, ...any[]]
 ) => {
@@ -265,10 +294,17 @@ export const Form = (props: FormProps) => {
 		FormClass,
 		style,
 		className,
+		customFetch,
 		...handlers
 	} = props;
+
+	// Try to get customFetch from FormioProvider context as fallback
+	const formioContext = useContext(FormioContext);
+	const effectiveCustomFetch = customFetch ?? formioContext?.customFetch;
+
 	const [formInstance, setFormInstance] = useState<Webform | null>(null);
 	const isMounted = useRef(false);
+	const previousFetchRef = useRef<typeof Formio.fetch | undefined>(undefined);
 
 	useEffect(() => {
 		return () => {
@@ -304,6 +340,13 @@ export const Form = (props: FormProps) => {
 				console.warn('Form source not found');
 				return;
 			}
+
+			// Apply customFetch to Formio.fetch before creating the form instance
+			if (effectiveCustomFetch) {
+				previousFetchRef.current = Formio.fetch;
+				Formio.fetch = effectiveCustomFetch;
+			}
+
 			currentFormJson.current =
 				formSource && typeof formSource !== 'string'
 					? structuredClone(formSource)
@@ -345,7 +388,15 @@ export const Form = (props: FormProps) => {
 		};
 
 		createInstance();
-	}, [formConstructor, formReadyCallback, formSource, options, url]);
+
+		// Cleanup: restore original fetch when this effect re-runs or on unmount
+		return () => {
+			if (effectiveCustomFetch && previousFetchRef.current !== undefined) {
+				Formio.fetch = previousFetchRef.current;
+				previousFetchRef.current = undefined;
+			}
+		};
+	}, [formConstructor, formReadyCallback, formSource, options, url, effectiveCustomFetch]);
 
 	useEffect(() => {
 		let onAnyHandler = null;

--- a/src/components/__tests__/customFetch.test.tsx
+++ b/src/components/__tests__/customFetch.test.tsx
@@ -1,0 +1,118 @@
+import { render, cleanup } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { Formio } from '@formio/js';
+
+import { Form } from '../Form';
+import { FormioProvider } from '../../contexts/FormioContext';
+
+const simpleForm = {
+	display: 'form' as const,
+	components: [
+		{
+			label: 'First Name',
+			key: 'firstName',
+			type: 'textfield',
+			input: true,
+		},
+	],
+};
+
+describe('customFetch prop', () => {
+	let originalFetch: typeof Formio.fetch;
+
+	beforeEach(() => {
+		originalFetch = Formio.fetch;
+	});
+
+	afterEach(() => {
+		// Always restore the original fetch after each test
+		Formio.fetch = originalFetch;
+		cleanup();
+	});
+
+	test('applies customFetch to Formio.fetch when provided as a prop', async () => {
+		const mockFetch = jest.fn(async () => new Response());
+
+		await new Promise<void>((resolve) => {
+			render(
+				<Form
+					src={simpleForm}
+					customFetch={mockFetch}
+					onFormReady={() => {
+						expect(Formio.fetch).toBe(mockFetch);
+						resolve();
+					}}
+				/>,
+			);
+		});
+	});
+
+	test('restores Formio.fetch to original value after unmount', async () => {
+		const mockFetch = jest.fn(async () => new Response());
+
+		const { unmount } = render(
+			<Form src={simpleForm} customFetch={mockFetch} />,
+		);
+
+		// Wait for the form to be created
+		await new Promise((resolve) => setTimeout(resolve, 500));
+
+		unmount();
+
+		// After unmount, Formio.fetch should be restored
+		expect(Formio.fetch).toBe(originalFetch);
+	});
+
+	test('does not modify Formio.fetch when customFetch is not provided', async () => {
+		await new Promise<void>((resolve) => {
+			render(
+				<Form
+					src={simpleForm}
+					onFormReady={() => {
+						expect(Formio.fetch).toBe(originalFetch);
+						resolve();
+					}}
+				/>,
+			);
+		});
+	});
+
+	test('uses customFetch from FormioProvider context', async () => {
+		const mockFetch = jest.fn(async () => new Response());
+
+		await new Promise<void>((resolve) => {
+			render(
+				<FormioProvider customFetch={mockFetch}>
+					<Form
+						src={simpleForm}
+						onFormReady={() => {
+							expect(Formio.fetch).toBe(mockFetch);
+							resolve();
+						}}
+					/>
+				</FormioProvider>,
+			);
+		});
+	});
+
+	test('Form-level customFetch overrides FormioProvider-level customFetch', async () => {
+		const providerFetch = jest.fn(async () => new Response());
+		const formFetch = jest.fn(async () => new Response());
+
+		await new Promise<void>((resolve) => {
+			render(
+				<FormioProvider customFetch={providerFetch}>
+					<Form
+						src={simpleForm}
+						customFetch={formFetch}
+						onFormReady={() => {
+							expect(Formio.fetch).toBe(formFetch);
+							expect(Formio.fetch).not.toBe(providerFetch);
+							resolve();
+						}}
+					/>
+				</FormioProvider>,
+			);
+		});
+	});
+});

--- a/src/contexts/FormioContext.tsx
+++ b/src/contexts/FormioContext.tsx
@@ -1,16 +1,28 @@
 import { createContext, useState, useEffect } from 'react';
 import { Formio as ImportedFormio } from '@formio/js';
 
+/**
+ * A custom fetch function type that matches the native fetch API signature.
+ * Can be passed to `<FormioProvider>` or `<Form>` to override the default
+ * fetch behavior used by Form.io for all HTTP requests.
+ */
+export type FormioCustomFetch = (
+	input: RequestInfo | URL,
+	init?: RequestInit,
+) => Promise<Response>;
+
 type BaseConfigurationArgs = {
 	baseUrl?: string;
 	projectUrl?: string;
 	Formio?: typeof ImportedFormio;
+	customFetch?: FormioCustomFetch;
 };
 
 const useBaseConfiguration = ({
 	baseUrl,
 	projectUrl,
 	Formio,
+	customFetch,
 }: BaseConfigurationArgs) => {
 	if (!Formio) {
 		if (baseUrl) {
@@ -23,6 +35,7 @@ const useBaseConfiguration = ({
 			Formio: ImportedFormio,
 			baseUrl: ImportedFormio.baseUrl,
 			projectUrl: ImportedFormio.projectUrl,
+			customFetch,
 		};
 	}
 
@@ -37,6 +50,7 @@ const useBaseConfiguration = ({
 		Formio,
 		baseUrl: Formio.baseUrl,
 		projectUrl: Formio.projectUrl,
+		customFetch,
 	};
 };
 
@@ -94,8 +108,9 @@ export function FormioProvider({
 	baseUrl,
 	projectUrl,
 	Formio,
+	customFetch,
 }: { children: React.ReactNode } & BaseConfigurationArgs) {
-	const baseConfig = useBaseConfiguration({ baseUrl, projectUrl, Formio });
+	const baseConfig = useBaseConfiguration({ baseUrl, projectUrl, Formio, customFetch });
 	const auth = useAuthentication({ Formio: baseConfig.Formio });
 	const formio = { ...baseConfig, ...auth };
 	return (

--- a/src/index.ts
+++ b/src/index.ts
@@ -10,6 +10,7 @@ export * from './components';
 export { useFormioContext } from './hooks/useFormioContext';
 export { usePagination } from './hooks/usePagination';
 export { FormioProvider } from './contexts/FormioContext';
+export type { FormioCustomFetch } from './contexts/FormioContext';
 export * from './constants';
 export * from './modules';
 export * from './types';


### PR DESCRIPTION
This PR introduces a React-idiomatic way to provide a custom fetch function to Form.io network requests. It adds a customFetch prop to both the <Form> component and the <FormioProvider>, eliminating the need for consumers to manually mutate the global Formio.fetch prototype as a side-effect.

🕵️‍♂️ Why are we making this change?
Currently, to customize the fetch function (e.g., for adding authorization headers, integrating React Query, or custom error handling), consumers must mutate the global module:

tsx
import { Formio } from 'formiojs';
Formio.fetch = myCustomFetchFunction; // Global side-effect!
This is problematic in React applications because:

Global Mutation: It affects every Form.io instance across the entire application.
Not React-Idiomatic: React components should be declarative and configurable via props, not by mutating globals before rendering.
Hard to Test: Testing different forms with different fetch strategies in the same suite causes global state to leak between tests.
🛠️ How is it implemented?
FormioCustomFetch Type: Exported a new type representing the native fetch API signature.
<FormioProvider> Integration: customFetch can be passed to the provider to act as the default fallback for all nested forms via React Context.
<Form> Component: Accepts a customFetch prop. Because @formio/core currently hardcodes network requests to the static Formio.fetch property, the <Form> component safely manages this global state internally. It intercepts the form instantiation, safely swaps Formio.fetch to the provided customFetch during initialization, and cleans up after itself on unmount.
🏗️ Architecture Note
Because the underlying @formio/core SDK does not currently support instance.fetch (it hardcodes the static Formio.fetch in Formio.request), the React wrapper manages this state via a useEffect cleanup pattern. If/when @formio/core supports true per-instance fetch properties, the internal logic of this React <Form> component can be updated with zero breaking changes to the consumer's public API.

📋 Testing & Verification
✅ Added customFetch.test.tsx testing the <Form> prop, the <FormioProvider> context fallback, override precedence, and unmount restoration.
✅ All 8 tests pass locally.
✅ Updated README.md with full usage examples for single-form and provider-level configurations.
📖 Code Example
tsx
import { Form } from '@formio/react';
// Easily scope fetch behavior to a specific form declaratively
const MyForm = () => (
  <Form
    src="https://examples.form.io/example"
    customFetch={async (url, init) => {
      const response = await fetch(url, {
        ...init,
        headers: {
          ...init?.headers,
          Authorization: `Bearer ${getToken()}`,
        },
      });
      return response;
    }}
  />
);
